### PR TITLE
Use appropriate integer type for pointers

### DIFF
--- a/ext/arrow-pycall/arrow-pycall.cpp
+++ b/ext/arrow-pycall/arrow-pycall.cpp
@@ -20,6 +20,29 @@
 
 #include <arrow/python/pyarrow.h>
 
+template<bool long_gteq_pointer>
+struct pointer2value {
+  VALUE operator()(void* ptr)
+  {
+    return LONG2NUM(reinterpret_cast<long>(ptr));
+  }
+};
+
+template<>
+struct pointer2value<false> {
+  VALUE operator()(void* ptr)
+  {
+    return LL2NUM((LONG_LONG)ptr);
+  }
+};
+
+static inline VALUE
+PTR2NUM(void* ptr)
+{
+  typedef pointer2value<(sizeof(long) >= sizeof(void*))> converter_type;
+  return converter_type()(ptr);
+}
+
 extern "C" void Init_arrow_pycall(void);
 
 static VALUE
@@ -28,7 +51,7 @@ rb_arrow_buffer_to_python_object_pointer(VALUE self)
   auto buffer = GARROW_BUFFER(RVAL2GOBJ(self));
   auto arrow_buffer = garrow_buffer_get_raw(buffer);
   auto py_buffer = arrow::py::wrap_buffer(arrow_buffer);
-  return LONG2NUM((long)(py_buffer));
+  return PTR2NUM(py_buffer);
 }
 
 static VALUE
@@ -37,7 +60,7 @@ rb_arrow_data_type_to_python_object_pointer(VALUE self)
   auto data_type = GARROW_DATA_TYPE(RVAL2GOBJ(self));
   auto arrow_data_type = garrow_data_type_get_raw(data_type);
   auto py_data_type = arrow::py::wrap_data_type(arrow_data_type);
-  return LONG2NUM((long)(py_data_type));
+  return PTR2NUM(y_data_type);
 }
 
 static VALUE
@@ -46,7 +69,7 @@ rb_arrow_field_to_python_object_pointer(VALUE self)
   auto field = GARROW_FIELD(RVAL2GOBJ(self));
   auto arrow_field = garrow_field_get_raw(field);
   auto py_field = arrow::py::wrap_field(arrow_field);
-  return LONG2NUM((long)(py_field));
+  return PTR2NUM(py_field);
 }
 
 static VALUE
@@ -55,7 +78,7 @@ rb_arrow_schema_to_python_object_pointer(VALUE self)
   auto schema = GARROW_SCHEMA(RVAL2GOBJ(self));
   auto arrow_schema = garrow_schema_get_raw(schema);
   auto py_schema = arrow::py::wrap_schema(arrow_schema);
-  return LONG2NUM((long)(py_schema));
+  return PTR2NUM(py_schema);
 }
 
 static VALUE
@@ -64,7 +87,7 @@ rb_arrow_array_to_python_object_pointer(VALUE self)
   auto array = GARROW_ARRAY(RVAL2GOBJ(self));
   auto arrow_array = garrow_array_get_raw(array);
   auto py_array = arrow::py::wrap_array(arrow_array);
-  return LONG2NUM((long)(py_array));
+  return PTR2NUM(py_array);
 }
 
 static VALUE
@@ -73,7 +96,7 @@ rb_arrow_tensor_to_python_object_pointer(VALUE self)
   auto tensor = GARROW_TENSOR(RVAL2GOBJ(self));
   auto arrow_tensor = garrow_tensor_get_raw(tensor);
   auto py_tensor = arrow::py::wrap_tensor(arrow_tensor);
-  return LONG2NUM((long)(py_tensor));
+  return PTR2NUM(py_tensor);
 }
 
 static VALUE
@@ -82,7 +105,7 @@ rb_arrow_column_to_python_object_pointer(VALUE self)
   auto column = GARROW_COLUMN(RVAL2GOBJ(self));
   auto arrow_column = garrow_column_get_raw(column);
   auto py_column = arrow::py::wrap_column(arrow_column);
-  return LONG2NUM((long)(py_column));
+  return PTR2NUM(py_column);
 }
 
 static VALUE
@@ -91,7 +114,7 @@ rb_arrow_table_to_python_object_pointer(VALUE self)
   auto table = GARROW_TABLE(RVAL2GOBJ(self));
   auto arrow_table = garrow_table_get_raw(table);
   auto py_table = arrow::py::wrap_table(arrow_table);
-  return LONG2NUM((long)(py_table));
+  return PTR2NUM(py_table);
 }
 
 static VALUE
@@ -100,7 +123,7 @@ rb_arrow_record_batch_to_python_object_pointer(VALUE self)
   auto record_batch = GARROW_RECORD_BATCH(RVAL2GOBJ(self));
   auto arrow_record_batch = garrow_record_batch_get_raw(record_batch);
   auto py_record_batch = arrow::py::wrap_record_batch(arrow_record_batch);
-  return LONG2NUM((long)(py_record_batch));
+  return PTR2NUM(py_record_batch);
 }
 
 extern "C" void


### PR DESCRIPTION
`long` may not be enough type to keep pointer values in some architectures, such as 64bit windows.

Unfortunately, I couldn't get done `bundle install` on my Mac, so I've not checked this change doesn't have any problems, yet.
